### PR TITLE
feat : Separate API Security Config From Page Security Config

### DIFF
--- a/src/main/java/com/v1/dgtimes/config/security/ApiSecurityConfig.java
+++ b/src/main/java/com/v1/dgtimes/config/security/ApiSecurityConfig.java
@@ -1,0 +1,37 @@
+package com.v1.dgtimes.config.security;
+
+import com.v1.dgtimes.config.security.userdetail.UserDetailServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.stereotype.Component;
+
+@Order(1)
+@Component
+@RequiredArgsConstructor
+public class ApiSecurityConfig extends WebSecurityConfigurerAdapter {
+    private final UserDetailServiceImpl userDetailService;
+
+    @Override
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+        auth.userDetailsService(userDetailService);
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .antMatcher("/api/**")
+                .csrf().disable()
+                .authorizeRequests()
+                .antMatchers("/api/bookmark").authenticated()
+                .anyRequest().permitAll()
+                .and()
+                .httpBasic()
+        ;
+    }
+}

--- a/src/main/java/com/v1/dgtimes/config/security/PageSecurityConfig.java
+++ b/src/main/java/com/v1/dgtimes/config/security/PageSecurityConfig.java
@@ -3,21 +3,24 @@ package com.v1.dgtimes.config.security;
 import com.v1.dgtimes.config.security.userdetail.UserDetailServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.header.writers.frameoptions.StaticAllowFromStrategy;
 import org.springframework.security.web.header.writers.frameoptions.XFrameOptionsHeaderWriter;
 
 import java.net.URI;
-
+@Order(2)
 @EnableWebSecurity(debug = false)
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 @RequiredArgsConstructor
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+public class PageSecurityConfig extends WebSecurityConfigurerAdapter {
 
     private final UserDetailServiceImpl userDetailService;
 
@@ -31,8 +34,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         http
                 .csrf().disable()
                 .authorizeRequests()
-                .antMatchers("/assets/**", "/", "/signup").permitAll()
-                .antMatchers("/api/**", "/users/signup").permitAll()
+                .antMatchers("/assets/**", "/", "/signup", "/users/signup").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .formLogin(
@@ -45,9 +47,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                         logout->logout
                                 .logoutUrl("/signout")
                                 .logoutSuccessUrl("/"))
-                .headers().frameOptions().disable().addHeaderWriter(
-                        new XFrameOptionsHeaderWriter(new StaticAllowFromStrategy(URI.create("*"))
-                ));
+        ;
     }
 
     @Override


### PR DESCRIPTION
API와 Page Security 설정이 한 곳에 뭉쳐있어서 서로 충돌했습니다.

그래서 두 부분을 분리해서 구현했습니다.

- PageSecurityConfig : page(form) 관련 Security 설정
- ApiSecurityConfig : API 관련 Security 설정

참고 : #60